### PR TITLE
unique_ptr Label::componentName strings

### DIFF
--- a/Source/ConnectView.cpp
+++ b/Source/ConnectView.cpp
@@ -85,7 +85,7 @@ publicGroupsListModel(this)
     mRemoteAddressStaticLabel->setJustificationType(Justification::centredRight);
     mRemoteAddressStaticLabel->setWantsKeyboardFocus(true);
 
-    mDirectConnectDescriptionLabel = std::make_unique<Label>("remaddrst", TRANS("Connect directly to other instances of SonoBus on your local network with the local address that they advertise. This is experimental, using a private group is recommended instead, and works fine on local networks."));
+    mDirectConnectDescriptionLabel = std::make_unique<Label>("dirconndesc", TRANS("Connect directly to other instances of SonoBus on your local network with the local address that they advertise. This is experimental, using a private group is recommended instead, and works fine on local networks."));
     mDirectConnectDescriptionLabel->setJustificationType(Justification::topLeft);
 
     mAddRemoteHostEditor = std::make_unique<TextEditor>("remaddredit");
@@ -143,21 +143,21 @@ publicGroupsListModel(this)
     configEditor(mServerUserPasswordEditor.get());
 
 
-    mServerUserStaticLabel = std::make_unique<Label>("localaddrst", TRANS("Your Displayed Name:"));
+    mServerUserStaticLabel = std::make_unique<Label>("serveruserst", TRANS("Your Displayed Name:"));
     configServerLabel(mServerUserStaticLabel.get());
     mServerUserStaticLabel->setMinimumHorizontalScale(0.8);
 
-    mServerUserPassStaticLabel = std::make_unique<Label>("localaddrst", TRANS("Password:"));
+    mServerUserPassStaticLabel = std::make_unique<Label>("serveruserpassst", TRANS("Password:"));
     configServerLabel(mServerUserPassStaticLabel.get());
 
-    mServerGroupStaticLabel = std::make_unique<Label>("localaddrst", TRANS("Group Name:"));
+    mServerGroupStaticLabel = std::make_unique<Label>("servergroupst", TRANS("Group Name:"));
     configServerLabel(mServerGroupStaticLabel.get());
     mServerGroupStaticLabel->setMinimumHorizontalScale(0.8);
 
-    mServerGroupPassStaticLabel = std::make_unique<Label>("localaddrst", TRANS("Password:"));
+    mServerGroupPassStaticLabel = std::make_unique<Label>("servergrouppassst", TRANS("Password:"));
     configServerLabel(mServerGroupPassStaticLabel.get());
 
-    mServerHostStaticLabel = std::make_unique<Label>("localaddrst", TRANS("Connection Server:"));
+    mServerHostStaticLabel = std::make_unique<Label>("serverhostst", TRANS("Connection Server:"));
     configServerLabel(mServerHostStaticLabel.get());
 
 
@@ -208,14 +208,14 @@ publicGroupsListModel(this)
     mServerInfoLabel->setColour(Label::textColourId, Colour(0x99dddddd));
     mServerInfoLabel->setMinimumHorizontalScale(0.85);
 
-    String servinfo = TRANS("The connection server is only used to help users find each other, no audio passes through it. All audio is sent directly between users (peer to peer).");
-    mServerAudioInfoLabel = std::make_unique<Label>("servinfo", servinfo);
+    String servaudioinfo = TRANS("The connection server is only used to help users find each other, no audio passes through it. All audio is sent directly between users (peer to peer).");
+    mServerAudioInfoLabel = std::make_unique<Label>("servaudioinfo", servaudioinfo);
     mServerAudioInfoLabel->setJustificationType(Justification::centredTop);
     mServerAudioInfoLabel->setFont(14);
     mServerAudioInfoLabel->setColour(Label::textColourId, Colour(0x99aaaaaa));
     mServerAudioInfoLabel->setMinimumHorizontalScale(0.75);
 
-    mMainStatusLabel = std::make_unique<Label>("servstat", "");
+    mMainStatusLabel = std::make_unique<Label>("mainstat", "");
     mMainStatusLabel->setJustificationType(Justification::centredRight);
     mMainStatusLabel->setFont(13);
     mMainStatusLabel->setColour(Label::textColourId, Colour(0x66ffffff));
@@ -261,13 +261,13 @@ publicGroupsListModel(this)
     mPublicServerHostEditor = std::make_unique<TextEditor>("pubsrvaddredit");
     mPublicServerHostEditor->setFont(Font(14));
     configEditor(mPublicServerHostEditor.get());
-    mPublicServerHostEditor->setTooltip(servinfo);
+    mPublicServerHostEditor->setTooltip(servaudioinfo);
 
     mPublicServerHostStaticLabel = std::make_unique<Label>("pubaddrst", TRANS("Connection Server:"));
     configServerLabel(mPublicServerHostStaticLabel.get());
     mPublicServerHostStaticLabel->setWantsKeyboardFocus(true);
 
-    mPublicServerUserStaticLabel = std::make_unique<Label>("localaddrst", TRANS("Your Displayed Name:"));
+    mPublicServerUserStaticLabel = std::make_unique<Label>("pubuserst", TRANS("Your Displayed Name:"));
     configServerLabel(mPublicServerUserStaticLabel.get());
     mPublicServerUserStaticLabel->setMinimumHorizontalScale(0.8);
 
@@ -285,7 +285,7 @@ publicGroupsListModel(this)
     mPublicGroupComponent->setColour(GroupComponent::outlineColourId, Colour::fromFloatRGBA(0.8, 0.8, 0.8, 0.1));
     mPublicGroupComponent->setTextLabelPosition(Justification::centred);
 
-    mPublicServerInfoStaticLabel = std::make_unique<Label>("pubinfo", TRANS("Select existing group below OR "));
+    mPublicServerInfoStaticLabel = std::make_unique<Label>("pubinfost", TRANS("Select existing group below OR "));
     configServerLabel(mPublicServerInfoStaticLabel.get());
     mPublicServerInfoStaticLabel->setFont(16);
     mPublicServerInfoStaticLabel->setMinimumHorizontalScale(0.8);

--- a/Source/PeersContainerView.cpp
+++ b/Source/PeersContainerView.cpp
@@ -463,7 +463,7 @@ PeerViewInfo * PeersContainerView::createPeerViewInfo()
     pvf->sendButtonImage->setAlpha(0.7f);
 
     
-    pvf->bufferTimeLabel = std::make_unique<Label>("level", TRANS("Jitter Buffer"));
+    pvf->bufferTimeLabel = std::make_unique<Label>("buf", TRANS("Jitter Buffer"));
     configLabel(pvf->bufferTimeLabel.get(), LabelTypeRegular);
 
     pvf->recvOptionsButton = std::make_unique<SonoDrawableButton>("menu", DrawableButton::ImageFitted);
@@ -492,7 +492,7 @@ PeerViewInfo * PeersContainerView::createPeerViewInfo()
         pvf->formatChoiceButton->addItem(processor.getAudioCodeFormatName(i), i);
     }
 
-    pvf->staticFormatChoiceLabel = std::make_unique<Label>("fmt", TRANS("Send Quality"));
+    pvf->staticFormatChoiceLabel = std::make_unique<Label>("sendfmtst", TRANS("Send Quality"));
     configLabel(pvf->staticFormatChoiceLabel.get(), LabelTypeRegular);
 
 
@@ -503,7 +503,7 @@ PeerViewInfo * PeersContainerView::createPeerViewInfo()
         pvf->remoteSendFormatChoiceButton->addItem(processor.getAudioCodeFormatName(i), i);
     }
 
-    pvf->staticRemoteSendFormatChoiceLabel = std::make_unique<Label>("fmt", TRANS("Preferred Recv Quality"));
+    pvf->staticRemoteSendFormatChoiceLabel = std::make_unique<Label>("recvfmtst", TRANS("Preferred Recv Quality"));
     configLabel(pvf->staticRemoteSendFormatChoiceLabel.get(), LabelTypeRegular);
 
     pvf->changeAllRecvFormatButton = std::make_unique<ToggleButton>(TRANS("Change all"));
@@ -511,11 +511,11 @@ PeerViewInfo * PeersContainerView::createPeerViewInfo()
     pvf->changeAllRecvFormatButton->setLookAndFeel(&pvf->smallLnf);
 
 
-    pvf->staticLatencyLabel = std::make_unique<Label>("lat", TRANS("Latency (ms)"));
+    pvf->staticLatencyLabel = std::make_unique<Label>("latst", TRANS("Latency (ms)"));
     configLabel(pvf->staticLatencyLabel.get(), LabelTypeSmallDim);
     pvf->staticLatencyLabel->setJustificationType(Justification::centred);
     
-    pvf->staticPingLabel = std::make_unique<Label>("ping", TRANS("Ping"));
+    pvf->staticPingLabel = std::make_unique<Label>("pingst", TRANS("Ping"));
     configLabel(pvf->staticPingLabel.get(), LabelTypeSmallDim);
 
     pvf->latencyLabel = std::make_unique<Label>("lat", TRANS("PRESS"));
@@ -525,9 +525,9 @@ PeerViewInfo * PeersContainerView::createPeerViewInfo()
     pvf->pingLabel = std::make_unique<Label>("ping");
     configLabel(pvf->pingLabel.get(), LabelTypeSmall);
 
-    pvf->staticSendQualLabel = std::make_unique<Label>("lat", TRANS("Send Quality:"));
+    pvf->staticSendQualLabel = std::make_unique<Label>("sendqualst", TRANS("Send Quality:"));
     configLabel(pvf->staticSendQualLabel.get(), LabelTypeSmallDim);
-    pvf->staticBufferLabel = std::make_unique<Label>("ping", TRANS("Recv Jitter Buffer:"));
+    pvf->staticBufferLabel = std::make_unique<Label>("bufst", TRANS("Recv Jitter Buffer:"));
     configLabel(pvf->staticBufferLabel.get(), LabelTypeSmallDim);
     
     pvf->sendQualityLabel = std::make_unique<Label>("qual", "");


### PR DESCRIPTION
I noticed many of the Label::componentName were reused, or were not following a consistent formatting. That was annoying to me when trying to debug label layout (which I guess is the main purpose of the Label::componentName). I don't believe this commit changes any behavior.

Note: this is same as #73 which I deleted because I forgot to change mPublicServerHostEditor->setTooltip to use the new name servaudioinfo instead of the old name servinfo