### PR TITLE
Check Full Mix if only checked Each Connected User

### DIFF
--- a/Source/OptionsView.cpp
+++ b/Source/OptionsView.cpp
@@ -938,9 +938,9 @@ void OptionsView::buttonClicked (Button* buttonThatWasClicked)
         recmask |= (mOptionsRecSelfButton->getToggleState() ? SonobusAudioProcessor::RecordSelf : 0);
         recmask |= (mOptionsRecMixMinusButton->getToggleState() ? SonobusAudioProcessor::RecordMixMinusSelf : 0);
 
-        // ensure at least one is selected
-        if (recmask == 0) {
-            recmask = SonobusAudioProcessor::RecordMix;
+        // check full mix if none checked or if user only checked "Each Connected User"
+        if (recmask == 0 || recmask == SonobusAudioProcessor::RecordIndividualUsers) {
+            recmask |= SonobusAudioProcessor::RecordMix;
             mOptionsRecMixButton->setToggleState(true, dontSendNotification);
         }
 


### PR DESCRIPTION
This is one simple but crude way to avoid issue #76 by forcibly checking "Full Mix" if somehow user only tried checking "Each Connected User".

It avoids headaches of user thinking that record button is not working.