### PR TITLE
Handle sonobus:// protocol in Linux

### DIFF
--- a/Builds/LinuxMakefile/sonobus.desktop
+++ b/Builds/LinuxMakefile/sonobus.desktop
@@ -8,3 +8,4 @@ Terminal=false
 Type=Application
 Categories=AudioVideo;Audio;Mixer;
 Keywords=live;online;music;conference;
+MimeType=x-scheme-handler/sonobus


### PR DESCRIPTION
This way, when Linux users go to a link from http://go.sonobus.net/sblaunch, they can click on "Open SonoBus" and actually open SonoBus.