### PR TITLE
Use a [P] prefix for public groups recents list

### DIFF
--- a/Source/ConnectView.cpp
+++ b/Source/ConnectView.cpp
@@ -1557,7 +1557,9 @@ void ConnectView::RecentsListModel::paintListBoxItem (int rowNumber, Graphics &g
     float iconsize = height*yratio;
     float groupheight = height*yratio;
     g.drawImageWithin(groupImage, 0, 0, iconsize, iconsize, RectanglePlacement::fillDestination);
-    g.drawFittedText (info.groupName, iconsize + 4, 0, adjwidth*xratio - 8 - iconsize, groupheight, Justification::centredLeft, true);
+    String grouptext;
+    grouptext << (info.groupIsPublic ? TRANS("[P] ") : "") << info.groupName;
+    g.drawFittedText (grouptext, iconsize + 4, 0, adjwidth*xratio - 8 - iconsize, groupheight, Justification::centredLeft, true);
 
     g.setFont (parent->recentsNameFont);
     g.setColour (parent->findColour(nameTextColourId).withAlpha(0.8f));


### PR DESCRIPTION
This is consistent with the group name as shown while inside the group and takes less space.

This is my first contribution to get a feel of the codebase, might eventually try to implement some of my feature requests