### PR TITLE
Add the exchange of a "supported codecs" list between clients and add a "PCM 8 bit" codec

### DIFF
--- a/Source/OptionsView.cpp
+++ b/Source/OptionsView.cpp
@@ -119,7 +119,8 @@ OptionsView::OptionsView(SonobusAudioProcessor& proc, std::function<AudioDeviceM
         SonobusAudioProcessor::AudioCodecFormatInfo finfo;
         processor.getAudioCodecFormatInfo(i, finfo);
         auto name = finfo.name;
-        if (finfo.codec == SonobusAudioProcessor::AudioCodecFormatCodec::CodecOpus && finfo.bitrate < 96000) {
+        if (finfo.codec == SonobusAudioProcessor::AudioCodecFormatCodec::CodecOpus && finfo.bitrate < 96000 ||
+            finfo.codec == SonobusAudioProcessor::AudioCodecFormatCodec::CodecPCM  && finfo.bitdepth == 1) {
             name += String(" (*)");
         }
         mOptionsFormatChoiceDefaultChoice->addItem(name, i+1);

--- a/Source/OptionsView.cpp
+++ b/Source/OptionsView.cpp
@@ -117,7 +117,7 @@ OptionsView::OptionsView(SonobusAudioProcessor& proc, std::function<AudioDeviceM
     int numformats = processor.getNumberAudioCodecFormats();
     for (int i=0; i < numformats; ++i) {
         SonobusAudioProcessor::AudioCodecFormatInfo finfo;
-        processor.getAudioCodeFormatInfo(i, finfo);
+        processor.getAudioCodecFormatInfo(i, finfo);
         auto name = finfo.name;
         if (finfo.codec == SonobusAudioProcessor::AudioCodecFormatCodec::CodecOpus && finfo.bitrate < 96000) {
             name += String(" (*)");

--- a/Source/PeersContainerView.cpp
+++ b/Source/PeersContainerView.cpp
@@ -1829,7 +1829,8 @@ void PeersContainerView::updateAvailableCodecOptions(const String & username) {
                 SonobusAudioProcessor::AudioCodecFormatInfo finfo;
                 processor.getAudioCodecFormatInfo(format, finfo);
                 auto name = finfo.name;
-                if (finfo.codec == SonobusAudioProcessor::AudioCodecFormatCodec::CodecOpus && finfo.bitrate < 96000) {
+                if (finfo.codec == SonobusAudioProcessor::AudioCodecFormatCodec::CodecOpus && finfo.bitrate < 96000 ||
+                    finfo.codec == SonobusAudioProcessor::AudioCodecFormatCodec::CodecPCM  && finfo.bitdepth == 1) {
                     name += String(" (*)");
                 }
                 pvf->formatChoiceButton->addItem(name, format);

--- a/Source/PeersContainerView.h
+++ b/Source/PeersContainerView.h
@@ -244,6 +244,7 @@ public:
 
     void setPeerDisplayMode(SonobusAudioProcessor::PeerDisplayMode mode);
 
+    void updateAvailableCodecOptions(const String & username);
 
 protected:
     

--- a/Source/SonobusPluginEditor.cpp
+++ b/Source/SonobusPluginEditor.cpp
@@ -1708,6 +1708,14 @@ void SonobusAudioProcessorEditor::peerBlockedInfoChanged(SonobusAudioProcessor *
 
 }
 
+void SonobusAudioProcessorEditor::peerCodecInfoReceived(SonobusAudioProcessor *comp, const String & username)
+{
+    {
+        const ScopedLock sl (clientStateLock);
+        clientEvents.add(ClientEvent(ClientEvent::PeerCodecInfoReceivedEvent, username));
+    }
+    triggerAsyncUpdate();
+}
 
 //////////////////////////
 
@@ -3938,6 +3946,8 @@ void SonobusAudioProcessorEditor::handleAsyncUpdate()
         }
         else if (ev.type == ClientEvent::PeerBlockedInfoChangedEvent) {
             updatePeerState(true);
+        } else if (ev.type == ClientEvent::PeerCodecInfoReceivedEvent) {
+            mPeerContainer->updateAvailableCodecOptions(ev.message);
         }
     }
 

--- a/Source/SonobusPluginEditor.h
+++ b/Source/SonobusPluginEditor.h
@@ -146,6 +146,7 @@ public:
     void sbChatEventReceived(SonobusAudioProcessor *comp, const SBChatEvent & mesg) override;
     void peerRequestedLatencyMatch(SonobusAudioProcessor *comp, const String & username, float latency) override;
     void peerBlockedInfoChanged(SonobusAudioProcessor *comp, const String & username, bool blocked) override;
+    void peerCodecInfoReceived(SonobusAudioProcessor *comp, const String & userName) override;
 
     std::function<AudioDeviceManager*()> getAudioDeviceManager; // = []() { return 0; };
     std::function<bool()> isInterAppAudioConnected; // = []() { return 0; };
@@ -454,6 +455,7 @@ private:
             PublicGroupDeletedEvent,
             PeerRequestedLatencyMatchEvent,
             PeerBlockedInfoChangedEvent,
+            PeerCodecInfoReceivedEvent,
             Error
         };
         

--- a/Source/SonobusPluginProcessor.cpp
+++ b/Source/SonobusPluginProcessor.cpp
@@ -359,6 +359,7 @@ struct SonobusAudioProcessor::RemotePeer {
     float remoteOutLatMs = 0.0f;
     int remoteNetType = RemoteNetTypeUnknown;
     bool remoteIsRecording = false;
+    std::set<Uuid> supportedCodecs;
     bool hasRemoteInfo = false;
     bool blockedUs = false;
 
@@ -1330,21 +1331,43 @@ void SonobusAudioProcessor::initFormats()
     
     // low bandwidth to high
     //mAudioFormats.add(AudioCodecFormatInfo(8000, 10, OPUS_SIGNAL_MUSIC, 960));
-    mAudioFormats.add(AudioCodecFormatInfo(16000, 10, OPUS_SIGNAL_MUSIC, 960));
-    mAudioFormats.add(AudioCodecFormatInfo(24000, 10, OPUS_SIGNAL_MUSIC, 480));
-    mAudioFormats.add(AudioCodecFormatInfo(48000, 10, OPUS_SIGNAL_MUSIC, 240));
-    mAudioFormats.add(AudioCodecFormatInfo(64000, 10, OPUS_SIGNAL_MUSIC, 240));
-    mAudioFormats.add(AudioCodecFormatInfo(96000, 10, OPUS_SIGNAL_MUSIC, 120));
-    mAudioFormats.add(AudioCodecFormatInfo(128000, 10, OPUS_SIGNAL_MUSIC, 120));
-    mAudioFormats.add(AudioCodecFormatInfo(160000, 10, OPUS_SIGNAL_MUSIC, 120));
-    mAudioFormats.add(AudioCodecFormatInfo(256000, 10, OPUS_SIGNAL_MUSIC, 120));
-    
-    mAudioFormats.add(AudioCodecFormatInfo(2));
-    mAudioFormats.add(AudioCodecFormatInfo(3));
-    mAudioFormats.add(AudioCodecFormatInfo(4));
+    mAudioFormats.add(AudioCodecFormatInfo(Uuid("d30affc3-db76-40fd-85bd-6ba4f67d75f0"), 16000, 10, OPUS_SIGNAL_MUSIC, 960));
+    mAudioFormats.add(AudioCodecFormatInfo(Uuid("540af31d-3047-420d-89d7-472c07dcbb2e"), 24000, 10, OPUS_SIGNAL_MUSIC, 480));
+    mAudioFormats.add(AudioCodecFormatInfo(Uuid("df40ba8a-3621-42d2-a9d7-b6fa0ef1be84"), 48000, 10, OPUS_SIGNAL_MUSIC, 240));
+    mAudioFormats.add(AudioCodecFormatInfo(Uuid("e440a4d9-a450-4462-8aa8-9b4af8576514"), 64000, 10, OPUS_SIGNAL_MUSIC, 240));
+    mAudioFormats.add(AudioCodecFormatInfo(Uuid("14aaab94-dbd6-4446-bf1b-64efb55f16f6"), 96000, 10, OPUS_SIGNAL_MUSIC, 120));
+    mAudioFormats.add(AudioCodecFormatInfo(Uuid("79dbf03b-c112-4517-aa1c-fa501fc7d0b6"), 128000, 10, OPUS_SIGNAL_MUSIC, 120));
+    mAudioFormats.add(AudioCodecFormatInfo(Uuid("4333f3e5-7537-4b94-af9a-dfd836d59055"), 160000, 10, OPUS_SIGNAL_MUSIC, 120));
+    mAudioFormats.add(AudioCodecFormatInfo(Uuid("46c728a4-d830-4388-a493-361cb3f7a220"), 256000, 10, OPUS_SIGNAL_MUSIC, 120));
+
+    mAudioFormats.add(AudioCodecFormatInfo(Uuid("d7942c5c-4802-425b-ac51-16e995af03cd"), 2));
+    mAudioFormats.add(AudioCodecFormatInfo(Uuid("70b9b5d8-e263-4053-a584-72a9e97ed97d"), 3));
+    mAudioFormats.add(AudioCodecFormatInfo(Uuid("9825290e-f2cf-41be-9ff8-0c25f60ae8ad"), 4));
     //mAudioFormats.add(AudioCodecFormatInfo(CodecPCM, 8)); // insanity!
 
     mDefaultAudioFormatIndex = 4; // 96kpbs/ch Opus
+}
+
+SonobusAudioProcessor::AudioCodecFormatInfo SonobusAudioProcessor::resolveOpusCodecInfo(int bitrate, int complexity, int signaltype) {
+    for (auto & format : mAudioFormats) {
+        if (format.codec == CodecOpus && format.bitrate == bitrate && format.complexity == complexity && format.signal_type == signaltype) {
+            DBG("resolved opus codec bitrate: " << format.bitrate << " complexity: " << format.complexity << " signaltype" << format.signal_type);
+            return format;
+        }
+    }
+    DBG("unable to resolve opus codec with bitrate: " << bitrate);
+    throw "opus codec not found";
+}
+
+SonobusAudioProcessor::AudioCodecFormatInfo SonobusAudioProcessor::resolvePcmCodecInfo(int bitdepth) {
+    for (auto & format : mAudioFormats) {
+        if (format.codec == CodecPCM && format.bitdepth == bitdepth) {
+            DBG("resolved pcm codec bitdepth: " << format.bitdepth);
+            return format;
+        }
+    }
+    DBG("unable to resolve pcm codec with bitdepth: " << bitdepth);
+    throw "pcm codec not found";
 }
 
 int SonobusAudioProcessor::findFormatIndex(SonobusAudioProcessor::AudioCodecFormatCodec codec, int bitrate, int bitdepth)
@@ -1367,7 +1390,7 @@ int SonobusAudioProcessor::findFormatIndex(SonobusAudioProcessor::AudioCodecForm
 }
 
 
-String SonobusAudioProcessor::getAudioCodeFormatName(int formatIndex) const
+String SonobusAudioProcessor::getAudioCodecFormatName(int formatIndex) const
 {
     if (formatIndex >= mAudioFormats.size() || formatIndex < 0) return "";
     
@@ -1375,7 +1398,7 @@ String SonobusAudioProcessor::getAudioCodeFormatName(int formatIndex) const
     return info.name;    
 }
 
-bool SonobusAudioProcessor::getAudioCodeFormatInfo(int formatIndex, AudioCodecFormatInfo & retinfo) const
+bool SonobusAudioProcessor::getAudioCodecFormatInfo(int formatIndex, AudioCodecFormatInfo & retinfo) const
 {
     if (formatIndex >= mAudioFormats.size() || formatIndex < 0) return false;
     retinfo = mAudioFormats.getReference(formatIndex);
@@ -1404,7 +1427,8 @@ void SonobusAudioProcessor::setDefaultAutoresizeBufferMode(AutoNetBufferMode fla
 void SonobusAudioProcessor::setRemotePeerAudioCodecFormat(int index, int formatIndex)
 {
     if (formatIndex >= mAudioFormats.size() || index >= mRemotePeers.size()) return;
-    
+    if (!doesPeerSupportCodec(mRemotePeers.getUnchecked(index), formatIndex)) return;
+
     const AudioCodecFormatInfo & info = mAudioFormats.getReference(formatIndex);
 
     const ScopedReadLock sl (mCoreLock);        
@@ -3073,20 +3097,89 @@ void SonobusAudioProcessor::handleRemotePeerInfoUpdate(RemotePeer * peer, const 
         DBG("peerinfo: Got remote recording: " << (int)isrec);
         peer->remoteIsRecording = isrec;
     }
+    if (infodata.hasProperty("supportedcodecs")) {
+        auto supportedCodecs = infodata.getProperty("supportedcodecs", var()).getArray();
+        for (auto& supportedCodec : *supportedCodecs) {
+            peer->supportedCodecs.insert(Uuid(supportedCodec));
+        }
+    } else {
+        // fallback mode if the client is too old to send codec support information
+        // static, because this map never changes, so avoid multiple unnecessary calls
+        static std::set<Uuid> fallbackSupportedCodecs = getSupportedFallbackCodecs();
+        peer->supportedCodecs = std::set(fallbackSupportedCodecs);
+    }
+    clientListeners.call(&SonobusAudioProcessor::ClientListener::peerCodecInfoReceived, this, peer->userName);
+
+    for (const auto & supportedCodec : peer->supportedCodecs) {
+        DBG("peerinfo: peer supports codec with ID: " << supportedCodec.toString());
+    }
 
     peer->hasRemoteInfo = true;
+}
 
+// returns all audio format indexes supported by the peer
+std::vector<int> SonobusAudioProcessor::getRemotePeerSupportedAudioFormatIndexes(int index) {
+    auto remote = mRemotePeers.getUnchecked(index);
+    std::vector<int> formats;
+    for (int i=0; i < mAudioFormats.size(); i++) {
+        for (const auto & supportedCodec : remote->supportedCodecs) {
+            if (supportedCodec == mAudioFormats[i].id) {
+                formats.push_back(i);
+                continue;
+            }
+        }
+    }
+    return formats;
+}
+
+// fallback mode, returns all codecs that are supported by the older clients which don't send any codec support information
+std::set<Uuid> SonobusAudioProcessor::getSupportedFallbackCodecs() {
+    std::set<Uuid> minimumSupportedCodecs;
+    minimumSupportedCodecs.insert(Uuid("d30affc3-db76-40fd-85bd-6ba4f67d75f0"));
+    minimumSupportedCodecs.insert(Uuid("540af31d-3047-420d-89d7-472c07dcbb2e"));
+    minimumSupportedCodecs.insert(Uuid("df40ba8a-3621-42d2-a9d7-b6fa0ef1be84"));
+    minimumSupportedCodecs.insert(Uuid("e440a4d9-a450-4462-8aa8-9b4af8576514"));
+    minimumSupportedCodecs.insert(Uuid("14aaab94-dbd6-4446-bf1b-64efb55f16f6"));
+    minimumSupportedCodecs.insert(Uuid("79dbf03b-c112-4517-aa1c-fa501fc7d0b6"));
+    minimumSupportedCodecs.insert(Uuid("4333f3e5-7537-4b94-af9a-dfd836d59055"));
+    minimumSupportedCodecs.insert(Uuid("46c728a4-d830-4388-a493-361cb3f7a220"));
+
+    minimumSupportedCodecs.insert(Uuid("d7942c5c-4802-425b-ac51-16e995af03cd"));
+    minimumSupportedCodecs.insert(Uuid("70b9b5d8-e263-4053-a584-72a9e97ed97d"));
+    minimumSupportedCodecs.insert(Uuid("9825290e-f2cf-41be-9ff8-0c25f60ae8ad"));
+    return minimumSupportedCodecs;
+}
+
+StringArray SonobusAudioProcessor::getSupportedCodecsByThisClient() {
+    StringArray supportedCodecs;
+    for (const auto & format : mAudioFormats) {
+         supportedCodecs.add(format.id.toString());
+    }
+    return supportedCodecs;
+}
+
+bool SonobusAudioProcessor::doesPeerSupportCodec(RemotePeer * peer, int audioFormatIndex) {
+    SonobusAudioProcessor::AudioCodecFormatInfo finfo;
+    getAudioCodecFormatInfo(audioFormatIndex, finfo);
+    for (auto & supportedCodec : peer->supportedCodecs) {
+        if (supportedCodec == finfo.id) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void SonobusAudioProcessor::sendRemotePeerInfoUpdate(int index, RemotePeer * topeer)
 {
     // send our info to this remote peer
     DynamicObject::Ptr info = new DynamicObject(); // this will delete itself
+    static StringArray supportedCodecs = getSupportedCodecsByThisClient();
 
     // not great, better than nothing - TODO make this accurate
     info->setProperty("inlat", 1e3 * currSamplesPerBlock / getSampleRate());
     info->setProperty("outlat", 1e3 * currSamplesPerBlock / getSampleRate());
     info->setProperty("rec", isRecordingToFile());
+    info->setProperty("supportedcodecs", supportedCodecs);
 
     // nettype TODO
 
@@ -3578,21 +3671,33 @@ int32_t SonobusAudioProcessor::handleSourceEvents(const aoo_event ** events, int
                     peer->latencysource->set_format(fmt.header);
                     peer->echosource->set_format(fmt.header);
 
-                    AudioCodecFormatCodec codec = String(fmt.header.codec) == AOO_CODEC_OPUS ? CodecOpus : CodecPCM;
-                    if (codec == CodecOpus) {
-                        aoo_format_opus *ofmt = (aoo_format_opus *)&fmt;
-                        int retindex = findFormatIndex(codec, ofmt->bitrate / ofmt->header.nchannels, 0);
-                        if (retindex >= 0) {
-                            peer->formatIndex = retindex; // new sending format index
+                    String codecHeader = String(fmt.header.codec);
+                    AudioCodecFormatCodec codec = codecHeader == AOO_CODEC_OPUS ? CodecOpus : codecHeader == AOO_CODEC_PCM ? CodecPCM : CodecUnknown;
+                    switch(codec) {
+                        case CodecOpus:
+                        {
+                            aoo_format_opus *ofmt = (aoo_format_opus *)&fmt;
+                            int retindex = findFormatIndex(codec, ofmt->bitrate / ofmt->header.nchannels, 0);
+                            if (retindex >= 0) {
+                                peer->formatIndex = retindex; // new sending format index
+                            }
+                            break;
                         }
-                    }
-                    else if (codec == CodecPCM) {
-                        aoo_format_pcm *pfmt = (aoo_format_pcm *)&fmt;
-                        int bdepth = pfmt->bitdepth == AOO_PCM_FLOAT32 ? 4 : pfmt->bitdepth == AOO_PCM_INT24 ? 3 : pfmt->bitdepth == AOO_PCM_FLOAT64 ? 8 : 2;
-                        int retindex = findFormatIndex(codec, 0, bdepth);
-                        if (retindex >= 0) {
-                            peer->formatIndex = retindex; // new sending format index
-                        }                        
+                        case CodecPCM:
+                        {
+                            aoo_format_pcm *pfmt = (aoo_format_pcm *)&fmt;
+                            int bdepth = pfmt->bitdepth == AOO_PCM_FLOAT32 ? 4 : pfmt->bitdepth == AOO_PCM_INT24 ? 3 : pfmt->bitdepth == AOO_PCM_FLOAT64 ? 8 : 2;
+                            int retindex = findFormatIndex(codec, 0, bdepth);
+                            if (retindex >= 0) {
+                                peer->formatIndex = retindex; // new sending format index
+                            }
+                            break;
+                        }
+                        default:
+                            // codec unknown, this should theoretically never happen
+                            // only if for example a newer client for some reason sends us some codec not yet known to us without
+                            // regarding our supported codecs, or if this client doesn't correctly transmit the supported codecs
+                            DBG("codec is unknown to this sonobus client: " << codecHeader);
                     }
                 }
                 
@@ -3747,18 +3852,33 @@ int32_t SonobusAudioProcessor::handleSinkEvents(const aoo_event ** events, int32
                          */
                     }
 
-
-                    
-                    AudioCodecFormatCodec codec = String(f.header.codec) == AOO_CODEC_OPUS ? CodecOpus : CodecPCM;
-                    if (codec == CodecOpus) {
-                        aoo_format_opus *fmt = (aoo_format_opus *)&f;
-                        peer->recvFormat = AudioCodecFormatInfo(fmt->bitrate/fmt->header.nchannels, fmt->complexity, fmt->signal_type);
-                        //peer->recvFormatIndex = findFormatIndex(codec, fmt->bitrate / fmt->header.nchannels, 0);
-                    } else {
-                        aoo_format_pcm *fmt = (aoo_format_pcm *)&f;
-                        int bitdepth = fmt->bitdepth == AOO_PCM_INT16 ? 2 : fmt->bitdepth == AOO_PCM_INT24  ? 3  : fmt->bitdepth == AOO_PCM_FLOAT32 ? 4 : fmt->bitdepth == AOO_PCM_FLOAT64  ? 8 : 2;
-                        peer->recvFormat = AudioCodecFormatInfo(bitdepth);
-                        //peer->recvFormatIndex = findFormatIndex(codec, 0, fmt->bitdepth);
+                    String codecHeader = String(f.header.codec);
+                    AudioCodecFormatCodec codec = codecHeader == AOO_CODEC_OPUS ? CodecOpus : codecHeader == AOO_CODEC_PCM ? CodecPCM : CodecUnknown;
+                    try {
+                        switch (codec) {
+                            case CodecOpus:
+                            {
+                                aoo_format_opus *fmt = (aoo_format_opus *)&f;
+                                peer->recvFormat = resolveOpusCodecInfo(fmt->bitrate/fmt->header.nchannels, fmt->complexity, fmt->signal_type);
+                                //peer->recvFormatIndex = findFormatIndex(codec, fmt->bitrate / fmt->header.nchannels, 0);
+                                break;
+                            }
+                            case CodecPCM:
+                            {
+                                aoo_format_pcm *fmt = (aoo_format_pcm *)&f;
+                                int bitdepth = fmt->bitdepth == AOO_PCM_INT16 ? 2 : fmt->bitdepth == AOO_PCM_INT24  ? 3  : fmt->bitdepth == AOO_PCM_FLOAT32 ? 4 : fmt->bitdepth == AOO_PCM_FLOAT64  ? 8 : 2;
+                                peer->recvFormat = resolvePcmCodecInfo(bitdepth);
+                                //peer->recvFormatIndex = findFormatIndex(codec, 0, fmt->bitdepth);
+                                break;
+                            }
+                            default:
+                                // codec unknown, this should theoretically never happen
+                                // only if for example a newer client for some reason sends us some codec not yet known to us without
+                                // regarding our supported codecs, or if this client doesn't correctly transmit the supported codecs
+                                DBG("codec is unknown to this sonobus client: " << codecHeader);
+                        }
+                    } catch (const char * exceptionMsg) {
+                        DBG("exception at resolving the codec: " << exceptionMsg);
                     }
                     
                     clientListeners.call(&SonobusAudioProcessor::ClientListener::aooClientPeerChangedState, this, "format");

--- a/Source/SonobusPluginProcessor.cpp
+++ b/Source/SonobusPluginProcessor.cpp
@@ -1310,6 +1310,9 @@ void SonobusAudioProcessor::AudioCodecFormatInfo::computeName()
         name = String::formatted("%d kbps/ch", bitrate/1000);
     }
     else {
+        if (bitdepth == 1) {
+            name = "PCM 8 bit";
+        }
         if (bitdepth == 2) {
             name = "PCM 16 bit";
         }
@@ -1340,6 +1343,7 @@ void SonobusAudioProcessor::initFormats()
     mAudioFormats.add(AudioCodecFormatInfo(Uuid("4333f3e5-7537-4b94-af9a-dfd836d59055"), 160000, 10, OPUS_SIGNAL_MUSIC, 120));
     mAudioFormats.add(AudioCodecFormatInfo(Uuid("46c728a4-d830-4388-a493-361cb3f7a220"), 256000, 10, OPUS_SIGNAL_MUSIC, 120));
 
+    mAudioFormats.add(AudioCodecFormatInfo(Uuid("25e8723d-4b66-4fa4-9c0b-1ee96ca74824"), 1));
     mAudioFormats.add(AudioCodecFormatInfo(Uuid("d7942c5c-4802-425b-ac51-16e995af03cd"), 2));
     mAudioFormats.add(AudioCodecFormatInfo(Uuid("70b9b5d8-e263-4053-a584-72a9e97ed97d"), 3));
     mAudioFormats.add(AudioCodecFormatInfo(Uuid("9825290e-f2cf-41be-9ff8-0c25f60ae8ad"), 4));
@@ -3686,7 +3690,7 @@ int32_t SonobusAudioProcessor::handleSourceEvents(const aoo_event ** events, int
                         case CodecPCM:
                         {
                             aoo_format_pcm *pfmt = (aoo_format_pcm *)&fmt;
-                            int bdepth = pfmt->bitdepth == AOO_PCM_FLOAT32 ? 4 : pfmt->bitdepth == AOO_PCM_INT24 ? 3 : pfmt->bitdepth == AOO_PCM_FLOAT64 ? 8 : 2;
+                            int bdepth = pfmt->bitdepth == AOO_PCM_FLOAT32 ? 4 : pfmt->bitdepth == AOO_PCM_INT24 ? 3 : pfmt->bitdepth == AOO_PCM_FLOAT64 ? 8 : pfmt->bitdepth == AOO_PCM_INT16 ? 2 : 1;
                             int retindex = findFormatIndex(codec, 0, bdepth);
                             if (retindex >= 0) {
                                 peer->formatIndex = retindex; // new sending format index
@@ -3866,7 +3870,7 @@ int32_t SonobusAudioProcessor::handleSinkEvents(const aoo_event ** events, int32
                             case CodecPCM:
                             {
                                 aoo_format_pcm *fmt = (aoo_format_pcm *)&f;
-                                int bitdepth = fmt->bitdepth == AOO_PCM_INT16 ? 2 : fmt->bitdepth == AOO_PCM_INT24  ? 3  : fmt->bitdepth == AOO_PCM_FLOAT32 ? 4 : fmt->bitdepth == AOO_PCM_FLOAT64  ? 8 : 2;
+                                int bitdepth = fmt->bitdepth == AOO_PCM_INT16 ? 2 : fmt->bitdepth == AOO_PCM_INT24  ? 3  : fmt->bitdepth == AOO_PCM_FLOAT32 ? 4 : fmt->bitdepth == AOO_PCM_FLOAT64 ? 8 : 1;
                                 peer->recvFormat = resolvePcmCodecInfo(bitdepth);
                                 //peer->recvFormatIndex = findFormatIndex(codec, 0, fmt->bitdepth);
                                 break;
@@ -6345,7 +6349,7 @@ bool SonobusAudioProcessor::formatInfoToAooFormat(const AudioCodecFormatInfo & i
             fmt->header.blocksize = currSamplesPerBlock >= info.min_preferred_blocksize ? currSamplesPerBlock : info.min_preferred_blocksize;
             fmt->header.samplerate = getSampleRate();
             fmt->header.nchannels = channels;
-            fmt->bitdepth = info.bitdepth == 2 ? AOO_PCM_INT16 : info.bitdepth == 3 ? AOO_PCM_INT24 : info.bitdepth == 4 ? AOO_PCM_FLOAT32 : info.bitdepth == 8 ? AOO_PCM_FLOAT64 : AOO_PCM_INT16;
+            fmt->bitdepth = info.bitdepth == 2 ? AOO_PCM_INT16 : info.bitdepth == 3 ? AOO_PCM_INT24 : info.bitdepth == 4 ? AOO_PCM_FLOAT32 : info.bitdepth == 8 ? AOO_PCM_FLOAT64 : AOO_PCM_INT8;
 
             return true;
         } 

--- a/deps/aoo/lib/aoo/aoo_pcm.h
+++ b/deps/aoo/lib/aoo/aoo_pcm.h
@@ -21,6 +21,9 @@ typedef enum
     AOO_PCM_INT24,
     AOO_PCM_FLOAT32,
     AOO_PCM_FLOAT64,
+    // int8 has been intentionally added to the last place before AOO_PCM_BITDEPTH_SIZE as moving it to another
+    // place WILL break old clients which will try to decode this enum
+    AOO_PCM_INT8,
     AOO_PCM_BITDEPTH_SIZE
 } aoo_pcm_bitdepth;
 

--- a/deps/aoo/pd/src/aoo_common.c
+++ b/deps/aoo/pd/src/aoo_common.c
@@ -229,6 +229,9 @@ int aoo_format_parse(void *x, aoo_format_storage *f, int argc, t_atom *argv)
 
         int bitdepth = argc > 3 ? atom_getfloat(argv + 3) : 4;
         switch (bitdepth){
+        case 1:
+            fmt->bitdepth = AOO_PCM_INT8;
+            break;
         case 2:
             fmt->bitdepth = AOO_PCM_INT16;
             break;
@@ -343,6 +346,9 @@ int aoo_format_toatoms(const aoo_format *f, int argc, t_atom *argv)
         aoo_format_pcm *fmt = (aoo_format_pcm *)f;
         int nbits;
         switch (fmt->bitdepth){
+        case AOO_PCM_INT8:
+            nbits = 1;
+            break;
         case AOO_PCM_INT16:
             nbits = 2;
             break;


### PR DESCRIPTION
This PR consists of two commits with two consecutive features.

The first commit adds the exchange of codec support information between clients so that the clients know which codecs are supported by their peers. The logic falls back to the currently supported codecs in v1.6.2  if no codec support information is received. This feature can be used to develop new codecs, to drop support of codecs or theoretically also for an individual user to have a choice for whitelisted codecs. UUIDs are used for the unique identification of codecs and codecs that aren't supported by a peer won't be in the visible in the dropdown by the user.

The second commit uses the previously described codec support information exchange feature to add an 8-bit PCM mode to the current PCM codec without disrupting clients that don't have this implementation. The 8-bit mode lowers the bandwidth requirements without adding the 2.5ms extra latency of the Opus codec. Furthermore noise shaped dithering is applied at encoding to achieve an acceptable audio quality. Still the new mode is marked as "(*) not recommended", because it adds some noise.

I implemented these features to jam with some friends at a lower latency while maintaining compatibility with older clients. Lower latency was achieved by sending redundant UDP packets with the freed bandwidth that was gained from switching from the 16-bit PCM over to the 8-bit PCM codec. This PR contains the codec changes and I'll open a second PR for the option to enable redundant packet transmission.

![image](https://github.com/sonosaurus/sonobus/assets/81837461/2a2e5582-716a-4b01-808f-c3023ee45225)
*PCM 8-bit selection*
