### PR TITLE
Fix various typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,7 +417,7 @@ function(sono_add_custom_plugin_target target_name product_name formats is_instr
     # This cleans up the folder organization, especially on Xcode.
     # It tucks the Plugin varieties into a "Targets" folder and generate an Xcode Scheme manually
     # Xcode scheme generation is turned off globally to limit noise from other targets
-    # The non-hacky way of doing this is via the global PREDEFINED_TARGETS_FOLDER propety
+    # The non-hacky way of doing this is via the global PREDEFINED_TARGETS_FOLDER property
     # However that doesn't seem to be working in Xcode
     # Not all plugin types (au, vst) available on each build type (win, macos, linux)
     foreach(target ${formats} "All")

--- a/Source/ChannelGroup.h
+++ b/Source/ChannelGroup.h
@@ -50,7 +50,7 @@ struct ChannelGroupParams
     float pan[MAX_CHANNELS] = { 0.0f };
     // used when numChannels == 2
     float panStereo[2] = {-1.0f, 1.0f }; // only use 2
-    float centerPanLaw = 0.596f; // center pan attentuation (default -4.5dB)
+    float centerPanLaw = 0.596f; // center pan attenuation (default -4.5dB)
 
     int panDestStartIndex = 0; // destination channel index
     int panDestChannels = 2; // destination number of channels

--- a/Source/ChannelGroupsView.cpp
+++ b/Source/ChannelGroupsView.cpp
@@ -2889,7 +2889,7 @@ void ChannelGroupsView::updateInputModeChannelViews(int specific)
 
         } else {
             pvf->panLabel->setVisible(true);
-            pvf->panSlider->setDoubleClickReturnValue(true, (chi & 2) ? 1.0f : -1.0f); // double click defaults to altenating left/right
+            pvf->panSlider->setDoubleClickReturnValue(true, (chi & 2) ? 1.0f : -1.0f); // double click defaults to alternating left/right
             pvf->panSlider->setVisible(true);
 
         }

--- a/Source/ChatView.cpp
+++ b/Source/ChatView.cpp
@@ -830,7 +830,7 @@ void ChatView::processNewChatMessages(int index, int count)
         auto & event = allChatEvents.getReference(i);
 
         if (event.targets.isNotEmpty()) {
-            // targetted message
+            // targeted message
             auto targetnames = StringArray::fromTokens(event.targets, "|", "");
 
             // append a private tab for them if necessary
@@ -858,7 +858,7 @@ void ChatView::processNewChatMessages(int index, int count)
                 mLastPrivateChatViewEventIndex[event.from] = i;
             }
             else {
-                // we are showing global, so skip any targetted things
+                // we are showing global, so skip any targeted things
                 
                 if (event.type == SBChatEvent::UserType) {
                     // but mark unread on the chat tab from this person

--- a/Source/MVerb.h
+++ b/Source/MVerb.h
@@ -552,7 +552,7 @@ public:
 		Clear();
     }
 
-	//get ouput and iterate
+	//get output and iterate
 	T operator()(T input)
     {
 		T output = buffer[index1];
@@ -641,7 +641,7 @@ public:
 		Clear();
     }
 
-	//get ouput and iterate
+	//get output and iterate
 	T operator()(T input)
     {
 		T output = buffer[index1];

--- a/Source/OptionsView.cpp
+++ b/Source/OptionsView.cpp
@@ -62,7 +62,7 @@ void OptionsView::initializeLanguages()
     languages.add(TRANS("Russian"));  languagesNative.add(juce::CharPointer_UTF8 ("p\xd1\x83\xd1\x81\xd1\x81\xd0\xba\xd0\xb8\xd0\xb9")); codes.add("ru");
 
 
-    // TOOD - parse any user files with localized_%s.txt in our settings folder and add as options if not existing already
+    // TODO - parse any user files with localized_%s.txt in our settings folder and add as options if not existing already
 
 }
 

--- a/Source/RandomSentenceGenerator.cpp
+++ b/Source/RandomSentenceGenerator.cpp
@@ -50,7 +50,7 @@ RandomSentenceGenerator::RandomSentenceGenerator(const std::string & fileName)
     ifstream inFile(fileName);
 
     
-    //if the file doesnt open
+    //if the file doesn't open
     if ( !inFile.is_open() )
     {
         cerr << "Unable to open " << fileName << " for reading. "; 

--- a/Source/SampleEditView.h
+++ b/Source/SampleEditView.h
@@ -308,7 +308,7 @@ private:
     std::unique_ptr<SonoDrawableButton> createColourButton(const int index);
 
     /**
-     * Updates the colour buttons to show a checkmark if its colour is slected and hide the checkmark if that colour
+     * Updates the colour buttons to show a checkmark if its colour is selected and hide the checkmark if that colour
      * has not been selected.
      */
     void updateColourButtonCheckmark();

--- a/Source/SonoStandaloneFilterApp.cpp
+++ b/Source/SonoStandaloneFilterApp.cpp
@@ -792,7 +792,7 @@ public:
             }
         }
         else {
-            DBG("was not actve: restarting");
+            DBG("was not active: restarting");
             mainWindow->getDeviceManager().restartLastAudioDevice();
         }
 

--- a/Source/SonobusPluginEditor.cpp
+++ b/Source/SonobusPluginEditor.cpp
@@ -2409,7 +2409,7 @@ void SonobusAudioProcessorEditor::requestRecordDir(std::function<void (URL)> cal
     File initopendir = mCurrOpenDir;
 #if JUCE_ANDROID
     initopendir = File::getSpecialLocation(File::SpecialLocationType::userMusicDirectory);
-    // doens't work
+    // doesn't work
 #endif
     
     mFileChooser.reset(new FileChooser(TRANS("Choose a location to store recorded files."),
@@ -5195,7 +5195,7 @@ public:
                     success = true;
                 }
                 
-                DBG("Finished triming file JOB to: " << pathname);
+                DBG("Finished trimming file JOB to: " << pathname);
             }
         }
         else {

--- a/Source/SonobusPluginProcessor.cpp
+++ b/Source/SonobusPluginProcessor.cpp
@@ -7528,7 +7528,7 @@ void SonobusAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuffer
     //int sendPanChannels = sendCh == 0 ?  inputBuffer.getNumChannels() : jmin(inputBuffer.getNumChannels(), jmax(mainBusOutputChannels, sendCh));
     int sendPanChannels = sendCh == 0 ?  inputPostBuffer.getNumChannels() : jmin(sendWorkBuffer.getNumChannels(), sendCh);
     //int panChannels = jmin(inputBuffer.getNumChannels(), jmax(mainBusOutputChannels, sendCh));
-    // if sending as mono, split the difference about applying gain attentuation for the number of input channels
+    // if sending as mono, split the difference about applying gain attenuation for the number of input channels
     float tgain = sendPanChannels == 1 && inputPostBuffer.getNumChannels() > 0 ? (1.0f/std::max(1.0f, (float)(inputPostBuffer.getNumChannels() * 0.5f))) : 1.0f;
 
     sendWorkBuffer.clear(0, numSamples);
@@ -8674,7 +8674,7 @@ void SonobusAudioProcessor::setStateInformationWithOptions (const void* data, in
                 // doublecheck it's a valid URL due to bad update
                 auto url = URL(urlstr);
                 if (url.getScheme().isEmpty()) {
-                    // asssume its a file
+                    // assume it's a file
                     DBG("Bad saved record URL: " << urlstr);
                     url = URL(File(urlstr));
                 }

--- a/doc/SonoBus User Guide.md
+++ b/doc/SonoBus User Guide.md
@@ -33,7 +33,7 @@ You will need:
 *   STRONGLY Recommended: An Ethernet cable, and/or adapters for connecting the computer to your router or cable modem.  WiFi works, but is an extra layer of packet sequencing and always adds a lot of jitter, requiring increased buffer sizes. SonoBus strongly recommends connection by Ethernet.
 *   Recommended: Wired headphones or earbuds.  Bluetooth headphones will not work because of the added delay (as much as 250ms) inherent in Bluetooth audio. Sound-isolating headphones are best. Without headphones, other musicians will hear an irritating echo from your speakers feeding back into your microphone (if you are using one).
 *   If you are on Windows, it is HIGHLY recommended that you use the ASIO driver option, either with the ASIO driver that works with your audio interface, or by installing [ASIO4ALL](http://www.asio4all.org) for your built-in audio or anything that doesn't have an ASIO driver of its own. See Also Related Resources below.
-*   Set the power management options/plan on your system to "High Performance" if possible, particulary if using a laptop device. This will reduce the possibility of CPU throttling and/or automatic USB device sleep from interfering with the smooth flow of audio. 
+*   Set the power management options/plan on your system to "High Performance" if possible, particularly if using a laptop device. This will reduce the possibility of CPU throttling and/or automatic USB device sleep from interfering with the smooth flow of audio. 
 *   Your experience may vary.  Sometimes the setup is very frustrating, but that is why we are writing this document - to help you get started. SonoBus might not work well if your internet connection is not fast enough, or if there is a lot of heavy traffic on the Internet, during “Internet Rush Hour.” Just try during another time when there is less internet traffic. Sometimes you can help things by adding port forwarding settings on your home Internet router, or DSL or cable modem may help, but this is beyond the scope of this document.
 
 ## About Latency
@@ -130,7 +130,7 @@ To create your own group, enter a good name and press the Create Group button. F
 Remember that every SonoBus user can see these public group names and so anyone can connect with you.
 
 #### Direct Connection
-SonoBus includes a Direct Tab for connecting to other devices in your local network, but this feature has only undergone limited testing, and is so it has only limited support. This does open up some interesting possiblities, noteably the patchbay experimental feature, and it is provided for further testing. It is available in the 'dots' menu at the top right of the Connect window.
+SonoBus includes a Direct Tab for connecting to other devices in your local network, but this feature has only undergone limited testing, and is so it has only limited support. This does open up some interesting possibilities, notably the patchbay experimental feature, and it is provided for further testing. It is available in the 'dots' menu at the top right of the Connect window.
 
 These 'direct' connections are mutually exclusive with the group feature and connection server. Instead, You will need to fill in the 'host' field with the IP address of one of the 'local' SonoBus clients (for example, your own device) and, for example, UDP port 12000.
 

--- a/linux/BUILDING.md
+++ b/linux/BUILDING.md
@@ -14,7 +14,7 @@ On Fedora run this script:
 ./fedora_get_prereqs.sh
 ```
 
-On other distros you'll have to insall the following development packages manually through your package manager:
+On other distros you'll have to install the following development packages manually through your package manager:
 
 * `libjack-jackd2-dev`
 * `libopus0`


### PR DESCRIPTION
Found via `codespell -q 3 -S "./deps,*.svg,./localization,./JUCE,./Source/wordmaker*" -L caf,dispath,inbetween,pard,sord`