### PR TITLE
Fix typo in SonoBus.pkgproj

### DIFF
--- a/release/macpkg/SonoBus.pkgproj
+++ b/release/macpkg/SonoBus.pkgproj
@@ -2696,14 +2696,14 @@
 		<dict>
 			<key>BACKGROUND</key>
 			<dict>
-				<key>APPAREANCES</key>
+				<key>APPEARANCES</key>
 				<dict>
 					<key>DARK_AQUA</key>
 					<dict/>
 					<key>LIGHT_AQUA</key>
 					<dict/>
 				</dict>
-				<key>SHARED_SETTINGS_FOR_ALL_APPAREANCES</key>
+				<key>SHARED_SETTINGS_FOR_ALL_APPEARANCES</key>
 				<true/>
 			</dict>
 			<key>INSTALLATION TYPE</key>


### PR DESCRIPTION
Separated from #227 because this alters config source.  I couldn't find any other typos in the source (https://github.com/search?q=repo%3Asonosaurus%2Fsonobus%20APPAREANCES&type=code)

Please review closely.